### PR TITLE
Feat/publish bulk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: nestjs-rabbitmq
+on:
+  pull_request:
+    branches:
+      - feat/publish-bulk
+jobs:
+  check-application:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,8 @@
 name: nestjs-rabbitmq
 on:
-  [push]
-  # pull_request:
-  #   branches:
-  #     - feat/publish-bulk
+  pull_request:
+    branches:
+      - main
 jobs:
   check-application:
     runs-on: ubuntu-latest
@@ -29,12 +28,12 @@ jobs:
       - name: Install depencencies
         run: pnpm i
 
-      - name: Esperar o RabbitMQ subir
+      - name: Wait for RabbitMQ to go up
         run: |
-          echo "Aguardando RabbitMQ..."
+          echo "Waiting RabbitMQ..."
           for i in {1..10}; do
             nc -z localhost 5672 && echo "RabbitMQ OK" && break
-            echo "Aguardando..."
+            echo "Waiting..."
             sleep 5
           done
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,9 @@
 name: nestjs-rabbitmq
 on:
-  pull_request:
-    branches:
-      - feat/publish-bulk
+  [push]
+  # pull_request:
+  #   branches:
+  #     - feat/publish-bulk
 jobs:
   check-application:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,39 @@ on:
 jobs:
   check-application:
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: heidiks/rabbitmq-delayed-message-exchange:latest
+        ports:
+          - 5672:5672
+          - 15672:15672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm test
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install depencencies
+        run: pnpm i
+
+      - name: Esperar o RabbitMQ subir
+        run: |
+          echo "Aguardando RabbitMQ..."
+          for i in {1..10}; do
+            nc -z localhost 5672 && echo "RabbitMQ OK" && break
+            echo "Aguardando..."
+            sleep 5
+          done
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ dist
 
 *example
 # End of https://www.toptal.com/developers/gitignore/api/node
+#
+#
+# Ignore shell script files
+*.sh

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [The configuration file](#the-configuration-file)
   - [Publishers](#publishers)
     - [Publishing messages](#publishing-messages)
+    - [Publishing messages in bulk](#publishing-messages-in-bulk)
     - [Custom headers](#custom-headers)
   - [Consumers](#consumers)
     - [The messageHandler callback](#the-messagehandler-callback)
@@ -168,10 +169,46 @@ async publishMeTyped() {
   //This will return an error if the object is not properly typed
 }
 ```
-
-The `publish()` method uses [Publish Confirms](https://www.rabbitmq.com/docs/confirms#publisher-confirms)
+The `publish()` and `publishBulk()` methods uses [Publish Confirms](https://www.rabbitmq.com/docs/confirms#publisher-confirms)
 to make sure that the message is delivered to the broker before returning
 the promise.
+
+### Publishing messages in bulk
+```typescript
+import { Injectable } from "@nestjs/common";
+import { RabbitMQService } from "@bgaldino/nestjs-rabbitmq";
+
+@Injectable()
+export class MyService {
+  constructor(private readonly rabbitMQService: RabbitMQService) {}
+}
+
+async publishMe(){
+  const faileds = await this.rabbitMQService.publishBulk('exchange_name', 'routing_key', [{}]);
+}
+
+//or
+
+async publishMeTyped() {
+  const faileds = await this.rabbitMQService.publishBulk<CustomType>('exchange_name', 'routing_key', [{}]);
+  //This will return an error if the object is not properly typed
+}
+```
+
+
+
+The `publishBulk()` method returns only the messages that failed to receive confirmation via Publish Confirms.
+
+The publishBulk() method also provides a batchSize option to control how many messages are sent in parallel. The default value is 100. Use this setting with caution, as setting it too high may lead to excessive memory usage or network saturation.
+
+### Exemple
+```typescript
+
+async publishMe(){
+  const faileds = await this.rabbitMQService.publishBulk('exchange_name', 'routing_key', [{}],{ batchSize: 500 },);
+}
+
+```
 
 ### Custom headers
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: heidiks/rabbitmq-delayed-message-exchange:latest
+    container_name: rabbitmq
+    restart: always
+    ports:
+      - '5672:5672'
+      - '15672:15672'
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    mem_limit: 512m
+    cpus: 0.2
+    networks:
+      - default
+
+volumes:
+  rabbitmq_data:
+    driver: local
+
+networks:
+  default:
+    driver: bridge

--- a/src/rabbitmq-service.ts
+++ b/src/rabbitmq-service.ts
@@ -100,9 +100,9 @@ export class RabbitMQService implements OnApplicationBootstrap {
     exchangeName: string,
     routingKey: string,
     messages: T[],
-    options?: PublishOptions,
-    batchSize: number = 100,
+    options?: PublishOptions & { batchSize?: number }
   ): Promise<T[]> {
+    const batchSize = options?.batchSize ?? 100;
     const faileds: T[] = [];
     for (let i = 0; i < messages.length; i += batchSize) {
       const chunk = messages.slice(i, i + batchSize);

--- a/test/amqp-connection-manager.spec.ts
+++ b/test/amqp-connection-manager.spec.ts
@@ -27,15 +27,9 @@ describe("AMQPConnectionManager", () => {
   let amqpManager: AMQPConnectionManager;
   let testService: RmqTestService;
   let moduleRef: TestingModule;
-  let globalConsumerCallbackSpy: any;
   let globalConsumerThrowSpy: any;
 
   beforeAll(async () => {
-    globalConsumerCallbackSpy = jest.spyOn(
-      RmqTestService.prototype,
-      "messageHandler",
-    );
-
     globalConsumerThrowSpy = jest.spyOn(
       RmqTestService.prototype,
       "throwHandler",
@@ -236,10 +230,7 @@ describe("AMQPConnectionManager", () => {
     });
 
     it("should publish an array of messages and return 1 failed message", async () => {
-      const rabbitPublish = jest.spyOn(
-        AMQPConnectionManager.publishChannelWrapper,
-        "publish",
-      );
+      jest.spyOn(AMQPConnectionManager.publishChannelWrapper, "publish");
       jest
         .spyOn(rabbitMqService, "publish")
         .mockResolvedValueOnce(false)

--- a/test/amqp-connection-manager.spec.ts
+++ b/test/amqp-connection-manager.spec.ts
@@ -73,10 +73,10 @@ describe("AMQPConnectionManager", () => {
     await moduleRef.close();
   });
 
-  afterEach(()=>{
+  afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
-  })
+  });
 
   it("should return a truthy connection health", async () => {
     expect(testService.rabbitService.checkHealth()).toBeTruthy();
@@ -187,7 +187,12 @@ describe("AMQPConnectionManager", () => {
       const isPublished = await rabbitMqService.publishBulk(
         TestConsumers[0].exchangeName,
         TestConsumers[0].routingKey as string,
-        [{ test: "published" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        [
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+        ],
         { correlationId: "123" },
       );
 
@@ -236,7 +241,9 @@ describe("AMQPConnectionManager", () => {
         "publish",
       );
       jest
-      .spyOn(rabbitMqService,"publish").mockResolvedValueOnce(false).mockResolvedValue(true)
+        .spyOn(rabbitMqService, "publish")
+        .mockResolvedValueOnce(false)
+        .mockResolvedValue(true);
       jest
         .spyOn(RmqTestService.prototype, "messageHandler")
         .mockImplementation(async () => {});
@@ -244,23 +251,26 @@ describe("AMQPConnectionManager", () => {
       const publisheds = await rabbitMqService.publishBulk<any>(
         TestConsumers[0].exchangeName,
         TestConsumers[0].routingKey as string,
-        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        [
+          { test: "failed" },
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+        ],
         { correlationId: "123" },
       );
 
-      expect(publisheds.length).toBe(1)
-      expect(publisheds[0].test).toBe("failed")
+      expect(publisheds.length).toBe(1);
+      expect(publisheds[0].test).toBe("failed");
     });
 
     it("should return messages that failed to publish if the connection to rabbitmq is lost", async () => {
-      const rabbitPublish = jest.spyOn(
-        AMQPConnectionManager.publishChannelWrapper,
-        "publish",
-      );
+      jest.spyOn(AMQPConnectionManager.publishChannelWrapper, "publish");
+      jest.spyOn(rabbitMqService, "publish").mockResolvedValue(true);
       jest
-      .spyOn(rabbitMqService,"publish").mockResolvedValue(true)
-      jest
-      .spyOn(rabbitMqService,"checkHealth").mockReturnValueOnce(1).mockReturnValue(0)
+        .spyOn(rabbitMqService, "checkHealth")
+        .mockReturnValueOnce(1)
+        .mockReturnValue(0);
       jest
         .spyOn(RmqTestService.prototype, "messageHandler")
         .mockImplementation(async () => {});
@@ -268,12 +278,16 @@ describe("AMQPConnectionManager", () => {
       const publisheds = await rabbitMqService.publishBulk<any>(
         TestConsumers[0].exchangeName,
         TestConsumers[0].routingKey as string,
-        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
-        { correlationId: "123" },
-        1
+        [
+          { test: "failed" },
+          { test: "published" },
+          { test: "published" },
+          { test: "published" },
+        ],
+        { correlationId: "123", batchSize: 1 },
       );
 
-      expect(publisheds.length).toBe(2)
+      expect(publisheds.length).toBe(2);
     });
   });
 

--- a/test/amqp-connection-manager.spec.ts
+++ b/test/amqp-connection-manager.spec.ts
@@ -73,6 +73,11 @@ describe("AMQPConnectionManager", () => {
     await moduleRef.close();
   });
 
+  afterEach(()=>{
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  })
+
   it("should return a truthy connection health", async () => {
     expect(testService.rabbitService.checkHealth()).toBeTruthy();
   });
@@ -162,6 +167,113 @@ describe("AMQPConnectionManager", () => {
           },
         }),
       );
+    });
+
+    it("should publish a array of messages to a declared exchange and log it with custom headers", async () => {
+      jest.clearAllMocks();
+
+      const spy = jest.spyOn(RabbitMQService.prototype, "publish");
+      const rabbitPublish = jest.spyOn(
+        AMQPConnectionManager.publishChannelWrapper,
+        "publish",
+      );
+
+      const loggerSpy = jest.spyOn(Logger.prototype, "log");
+
+      jest
+        .spyOn(RmqTestService.prototype, "messageHandler")
+        .mockImplementation(async () => {});
+
+      const isPublished = await rabbitMqService.publishBulk(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].routingKey as string,
+        [{ test: "published" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        { correlationId: "123" },
+      );
+
+      expect(spy).toHaveBeenCalled();
+
+      expect(rabbitPublish).toHaveBeenCalledWith(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].queue,
+        JSON.stringify({ test: "published" }),
+        {
+          correlationId: "123",
+          deliveryMode: 2,
+          persistent: true,
+          headers: {
+            "x-application-headers": {
+              "original-exchange": TestConsumers[0].exchangeName,
+              "original-routing-key": TestConsumers[0].routingKey,
+              "published-at": expect.any(String),
+            },
+          },
+        },
+      );
+
+      expect(isPublished).toBeTruthy();
+
+      expect(loggerSpy.mock.lastCall?.[0]).toMatchObject(
+        expect.objectContaining({
+          logLevel: "log",
+          title: `[AMQP] [PUBLISH] [${TestConsumers[0].exchangeName}] [${TestConsumers[0].routingKey}]`,
+          binding: {
+            routingKey: TestConsumers[0].routingKey,
+            exchange: TestConsumers[0].exchangeName,
+          },
+          correlationId: "123",
+          publishedMessage: {
+            content: { test: "published" },
+            properties: { correlationId: "123" },
+          },
+        }),
+      );
+    });
+
+    it("should publish an array of messages and return 1 failed message", async () => {
+      const rabbitPublish = jest.spyOn(
+        AMQPConnectionManager.publishChannelWrapper,
+        "publish",
+      );
+      jest
+      .spyOn(rabbitMqService,"publish").mockResolvedValueOnce(false).mockResolvedValue(true)
+      jest
+        .spyOn(RmqTestService.prototype, "messageHandler")
+        .mockImplementation(async () => {});
+
+      const publisheds = await rabbitMqService.publishBulk<any>(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].routingKey as string,
+        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        { correlationId: "123" },
+      );
+
+      expect(publisheds.length).toBe(1)
+      expect(publisheds[0].test).toBe("failed")
+    });
+
+    it("should return messages that failed to publish if the connection to rabbitmq is lost", async () => {
+      const rabbitPublish = jest.spyOn(
+        AMQPConnectionManager.publishChannelWrapper,
+        "publish",
+      );
+      jest
+      .spyOn(rabbitMqService,"publish").mockResolvedValue(true)
+      jest
+      .spyOn(rabbitMqService,"checkHealth").mockReturnValueOnce(1).mockReturnValue(0)
+      jest
+        .spyOn(RmqTestService.prototype, "messageHandler")
+        .mockImplementation(async () => {});
+
+      const publisheds = await rabbitMqService.publishBulk<any>(
+        TestConsumers[0].exchangeName,
+        TestConsumers[0].routingKey as string,
+        [{ test: "failed" },{ test: "published" },{ test: "published" },{ test: "published" }],
+        { correlationId: "123" },
+        1
+      );
+
+      expect(publisheds.length).toBe(2)
     });
   });
 


### PR DESCRIPTION
### Description
This PR introduces a new feature that allows bulk publishing of messages to RabbitMQ within the NestJS integration library. This improvement is particularly useful for scenarios that require high throughput, such as batch processing.

Tests
![image](https://github.com/user-attachments/assets/e81d1243-0325-4905-a096-c9c30572a8bf)

### Performance test
#### Scenario
240mb of memory, ryzen 5 3600 processor, 100k messages

### Results
![image](https://github.com/user-attachments/assets/6a73d154-fb72-4ad2-a711-c017ebd87f9f)

- peak memory consumption 140mb
- response time 21s

** Also testing on a kubernets pod with 250mi of processor and 250mb of ram, same results.






